### PR TITLE
로그인 로그아웃을 고려한 코드 수정

### DIFF
--- a/src/main/java/com/cakestation/backend/user/controller/UserController.java
+++ b/src/main/java/com/cakestation/backend/user/controller/UserController.java
@@ -1,90 +1,101 @@
 package com.cakestation.backend.user.controller;
 
 import com.cakestation.backend.common.ApiResponse;
-import com.cakestation.backend.config.KakaoConfig;
 import com.cakestation.backend.user.domain.User;
 import com.cakestation.backend.user.repository.UserRepository;
-import com.cakestation.backend.user.service.KakaoService;
-import com.cakestation.backend.user.service.UserService;
+import com.cakestation.backend.user.service.*;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.cakestation.backend.user.dto.response.KakaoUserDto;
 import com.cakestation.backend.user.dto.response.TokenDto;
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.view.RedirectView;
 
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.*;
 import java.io.*;
-import java.net.HttpURLConnection;
-import java.net.URL;
 import java.net.URLEncoder;
 import java.util.List;
 
-import static com.cakestation.backend.config.KakaoConfig.REDIRECT_URI;
-import static com.cakestation.backend.config.KakaoConfig.REST_API_KEY;
+import lombok.RequiredArgsConstructor;
+
+import static com.cakestation.backend.config.KakaoConfig.*;
 
 @RestController
 @RequiredArgsConstructor
 public class UserController {
 
+    
     private final KakaoService kakaoService;
     private final UserService userService;
 
-    //    @GetMapping("/login")
-//    public  void loginAction() throws IOException {
-//        URL url = new URL("https://kauth.kakao.com/oauth/authorize");
-////      //?response_type=code&client_id="+ KakaoConfig.REST_API_KEY +"uri="+KakaoConfig.REDIRECT_URI
-//        HttpURLConnection con = (HttpURLConnection)url.openConnection();
-//        con.setRequestMethod("GET");
-//        con.setDoOutput(true);
-//        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(con.getOutputStream()));
-//        StringBuilder sb = new StringBuilder();
-//        sb.append("response_type=code");
-//        sb.append("&client_id=" + REST_API_KEY); // TODO REST_API_KEY 입력
-//        sb.append("&uri=" + REDIRECT_URI); // TODO 인가코드 받은 redirect_uri 입력
-//        bw.write(sb.toString());
-//        bw.flush();
-//
-//        int responseCode = con.getResponseCode();
-//        System.out.println("responseCode :::: " + responseCode);
-//        BufferedReader br = new BufferedReader(new InputStreamReader(con.getInputStream()));
-//        System.out.println("result :::: " + br.readLine());
-//    }
     @RequestMapping("/login")
     public RedirectView exRedirect4() {
         RedirectView redirectView = new RedirectView();
-        redirectView.setUrl("https://kauth.kakao.com/oauth/authorize?response_type=code&client_id="+ KakaoConfig.REST_API_KEY +"&redirect_uri="+KakaoConfig.REDIRECT_URI);
+
+        //추후 refresh토큰 확인 후 바로 accessToken발급 상태로 전환
+        //없을 경우 아래 redirect url을 통해 새로운 토큰 발급
+        redirectView.setUrl(REDIRECT_LOGINPAGE);
+
         return redirectView;
     }
     //인가 코드 반환
     @GetMapping("/oauth/kakao")
-    public ResponseEntity KakaoCallback(@RequestParam String code, HttpServletResponse response) {
-        TokenDto tokenDto = kakaoService.getKaKaoAccessToken(code);
-        KakaoUserDto kakaoUserDto = kakaoService.getUserInfo(tokenDto.getAccessToken());
-
-        //톰캣의 쿠키규칙으로 공백을 포함할수 없어서 utf-8로 인코딩을 해야함
-        String cookieValue;
+    public ResponseEntity KakaoCallback(@RequestParam(value = "code") String code, HttpServletResponse response) {
+        
+        JsonElement tokenResponse;
+        JsonElement userResponse;
+        TokenDto tokenDto;
+        String accessCookie;
+        //!!! 추후 refresh처리방안 논의할 예정 
+        String refreshCookie;
+        KakaoUserDto kakaoUserDto = null;
+        
         try {
-            // Bearer 정책을 활용하여 중간에 띄어쓰기를 위해 인코딩을하니 공백이 +로 변경되는 문제 발생
-            cookieValue = URLEncoder.encode("Bearer " + tokenDto.getAccessToken(), "utf-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
+            
+            // --- 토큰을 얻은뒤 setCookies에 Authorization의 Value 값으로 넣어주기 
+            tokenResponse = HttpUtil.getTokenurl(GET_TOKEN_URL+"&code="+code);
+            tokenDto = TokenDto.builder()
+            .accessToken(tokenResponse.getAsJsonObject().get("access_token").getAsString())
+            .refreshToken(tokenResponse.getAsJsonObject().get("refresh_token").getAsString())
+            .build();
+            
+            //!!! 톰캣의 쿠키규칙으로 공백을 포함할수 없어서 utf-8로 인코딩을 해야함
+            //!!! Bearer 정책을 활용하여 중간에 띄어쓰기를 위해 인코딩을하니 공백이 +로 변경되는 문제 발생
+            accessCookie = URLEncoder.encode("Bearer " + tokenDto.getAccessToken(), "utf-8");
+            refreshCookie = URLEncoder.encode("Bearer " + tokenDto.getRefreshToken(), "utf-8");
+            Cookie setCookie = new Cookie("Authorization", accessCookie);
+            
+            // ->쿠키 시간을 하루로 지정(60초*60분*24시간) 임의 지정
+            setCookie.setMaxAge(60 * 60 * 24);
+            response.addCookie(setCookie);
+            
+            // --- 토큰을 통한 유저정보 조회 및 저장
+            userResponse = HttpUtil.sendKakao(GET_USER_URL,tokenDto.getAccessToken());
+            JsonObject account = userResponse.getAsJsonObject().get("kakao_account").getAsJsonObject();
+    
+                String username = account.getAsJsonObject().get("profile").getAsJsonObject().get("nickname").getAsString();
+                String email = account.getAsJsonObject().get("email").getAsString();
+                
+            kakaoUserDto = KakaoUserDto.builder()
+                        .username(username)
+                        .email(email)
+                        .build();
+                        
+            userService.join(kakaoUserDto);
+ 
+            
+        } catch (IOException e) {
+            e.printStackTrace();
         }
 
-        Cookie setCookie = new Cookie("Authorization", cookieValue);
-        //쿠키 시간을 하루로 지정(60초*60분*24시간)
-        setCookie.setMaxAge(60 * 60 * 24);
-        response.addCookie(setCookie);
-
-        Long userId = userService.join(kakaoUserDto);
         return new ResponseEntity<>(new ApiResponse(200, "로그인 성공", kakaoUserDto), HttpStatus.OK);
     }
 
     //로그아웃
-    @GetMapping("/logout/kakao")
+    @GetMapping("/logout")
     public ResponseEntity logout(){
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/cakestation/backend/user/controller/UserController.java
+++ b/src/main/java/com/cakestation/backend/user/controller/UserController.java
@@ -34,7 +34,7 @@ public class UserController {
     @RequestMapping("/login")
     public RedirectView exRedirect4() {
         RedirectView redirectView = new RedirectView();
-
+        
         //추후 refresh토큰 확인 후 바로 accessToken발급 상태로 전환
         //없을 경우 아래 redirect url을 통해 새로운 토큰 발급
         redirectView.setUrl(REDIRECT_LOGINPAGE);
@@ -103,7 +103,9 @@ public class UserController {
     private final UserRepository userRepository;
     @GetMapping("/userinfo")
     @ResponseBody
+    //Entity 를 DTO로 만들어서 반환할 수 있도록 할것
     public List<User> userInfo(){
+        //Service에 Userinfo를 호출해서 값을 만들수 있도록 할것
         List<User> userList = userRepository.findAll();
         return  userList;
     }

--- a/src/main/java/com/cakestation/backend/user/controller/UserController.java
+++ b/src/main/java/com/cakestation/backend/user/controller/UserController.java
@@ -1,6 +1,9 @@
 package com.cakestation.backend.user.controller;
 
 import com.cakestation.backend.common.ApiResponse;
+import com.cakestation.backend.config.KakaoConfig;
+import com.cakestation.backend.user.domain.User;
+import com.cakestation.backend.user.repository.UserRepository;
 import com.cakestation.backend.user.service.KakaoService;
 import com.cakestation.backend.user.service.UserService;
 import com.cakestation.backend.user.dto.response.KakaoUserDto;
@@ -9,9 +12,19 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.view.RedirectView;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
+import java.io.*;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.util.List;
+
+import static com.cakestation.backend.config.KakaoConfig.REDIRECT_URI;
+import static com.cakestation.backend.config.KakaoConfig.REST_API_KEY;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,16 +33,54 @@ public class UserController {
     private final KakaoService kakaoService;
     private final UserService userService;
 
+    //    @GetMapping("/login")
+//    public  void loginAction() throws IOException {
+//        URL url = new URL("https://kauth.kakao.com/oauth/authorize");
+////      //?response_type=code&client_id="+ KakaoConfig.REST_API_KEY +"uri="+KakaoConfig.REDIRECT_URI
+//        HttpURLConnection con = (HttpURLConnection)url.openConnection();
+//        con.setRequestMethod("GET");
+//        con.setDoOutput(true);
+//        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(con.getOutputStream()));
+//        StringBuilder sb = new StringBuilder();
+//        sb.append("response_type=code");
+//        sb.append("&client_id=" + REST_API_KEY); // TODO REST_API_KEY 입력
+//        sb.append("&uri=" + REDIRECT_URI); // TODO 인가코드 받은 redirect_uri 입력
+//        bw.write(sb.toString());
+//        bw.flush();
+//
+//        int responseCode = con.getResponseCode();
+//        System.out.println("responseCode :::: " + responseCode);
+//        BufferedReader br = new BufferedReader(new InputStreamReader(con.getInputStream()));
+//        System.out.println("result :::: " + br.readLine());
+//    }
+    @RequestMapping("/login")
+    public RedirectView exRedirect4() {
+        RedirectView redirectView = new RedirectView();
+        redirectView.setUrl("https://kauth.kakao.com/oauth/authorize?response_type=code&client_id="+ KakaoConfig.REST_API_KEY +"&redirect_uri="+KakaoConfig.REDIRECT_URI);
+        return redirectView;
+    }
     //인가 코드 반환
     @GetMapping("/oauth/kakao")
-    public ResponseEntity KakaoCallback(@RequestParam String code) {
+    public ResponseEntity KakaoCallback(@RequestParam String code, HttpServletResponse response) {
         TokenDto tokenDto = kakaoService.getKaKaoAccessToken(code);
-        KakaoUserDto kakaoUserDto =  kakaoService.getUserInfo(tokenDto.getAccessToken());
-        HttpHeaders httpHeaders = new HttpHeaders();
-        httpHeaders.add("Authorization", "Bearer " + tokenDto.getAccessToken());
+        KakaoUserDto kakaoUserDto = kakaoService.getUserInfo(tokenDto.getAccessToken());
+
+        //톰캣의 쿠키규칙으로 공백을 포함할수 없어서 utf-8로 인코딩을 해야함
+        String cookieValue;
+        try {
+            // Bearer 정책을 활용하여 중간에 띄어쓰기를 위해 인코딩을하니 공백이 +로 변경되는 문제 발생
+            cookieValue = URLEncoder.encode("Bearer " + tokenDto.getAccessToken(), "utf-8");
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
+
+        Cookie setCookie = new Cookie("Authorization", cookieValue);
+        //쿠키 시간을 하루로 지정(60초*60분*24시간)
+        setCookie.setMaxAge(60 * 60 * 24);
+        response.addCookie(setCookie);
 
         Long userId = userService.join(kakaoUserDto);
-        return new ResponseEntity<>(new ApiResponse(200,"로그인 성공",kakaoUserDto), httpHeaders, HttpStatus.OK);
+        return new ResponseEntity<>(new ApiResponse(200, "로그인 성공", kakaoUserDto), HttpStatus.OK);
     }
 
     //로그아웃
@@ -37,4 +88,14 @@ public class UserController {
     public ResponseEntity logout(){
         return ResponseEntity.ok().build();
     }
+
+    private final UserRepository userRepository;
+    @GetMapping("/userinfo")
+    @ResponseBody
+    public List<User> userInfo(){
+        List<User> userList = userRepository.findAll();
+        return  userList;
+    }
+
 }
+

--- a/src/main/java/com/cakestation/backend/user/service/HttpUtil.java
+++ b/src/main/java/com/cakestation/backend/user/service/HttpUtil.java
@@ -1,0 +1,85 @@
+package com.cakestation.backend.user.service;
+
+import java.io.*;
+import java.net.*;
+import java.nio.Buffer;
+
+import javax.servlet.http.Cookie;
+
+import com.cakestation.backend.user.dto.response.KakaoUserDto;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+
+public class HttpUtil {
+    //query params에 데이터값을 넣어줘야 할경우
+    //최초 토큰을 받아올때
+    //refresh Token을 받아올때 
+    public static JsonElement getTokenurl(String targetUrl) throws IOException {
+
+        JsonElement element = null;
+
+        try {
+            URL url = new URL(targetUrl);
+            HttpURLConnection con = (HttpURLConnection) url.openConnection();
+
+            //POST 요청을 위해 기본값이 false인 setDoOutput을 true로
+            con.setRequestMethod("POST");
+            con.setDoOutput(true);
+            int responseCode = con.getResponseCode();
+            BufferedReader br = new BufferedReader(new InputStreamReader(con.getInputStream()));
+
+            //받은 값들을 확인
+            String line = "";
+            String result = "";
+            while ((line = br.readLine()) != null) {
+                result += line;
+            }
+            //JSON데이터를 확인
+            JsonParser parser = new JsonParser();
+            element = parser.parse(result);
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        } 
+        
+        return element;
+    }
+    
+    //Header에 Authorization으로 토큰값을 Bearer정책에 맞춰 전달해야할 경우 
+    //로그아웃
+    //유저 정보찾기
+    //회원탈퇴
+    public static JsonElement sendKakao(String targetUrl,String checkValue) throws IOException {
+
+        JsonElement element = null;
+
+        try {
+            URL url = new URL(targetUrl);
+            HttpURLConnection con = (HttpURLConnection) url.openConnection();
+
+            //POST 요청을 위해 기본값이 false인 setDoOutput을 true로
+            con.setRequestMethod("POST");
+            con.setDoOutput(true);
+            con.setRequestProperty("Authorization", "Bearer " + checkValue);
+
+            int responseCode = con.getResponseCode();
+            BufferedReader br = new BufferedReader(new InputStreamReader(con.getInputStream()));
+
+            //받은 값들을 확인
+            String line = "";
+            String result = "";
+            while ((line = br.readLine()) != null) {
+                result += line;
+            }
+            //JSON데이터를 확인
+            JsonParser parser = new JsonParser();
+            element = parser.parse(result);
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        } 
+        
+        return element;
+    }
+    
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,20 @@
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        #show_sql: true
+        format_sql: true
+        default_batch_fetch_size: 100
+        dialect: org.hibernate.dialect.MySQL57Dialect
+    defer-datasource-initialization: true
+
+logging.level:
+  org.hibernate.SQL: debug
+  org.springframework.boot.autoconfigure: error
+#  org.hibernate.type: trace
+---
+spring:
+  profiles:
+    active: dev


### PR DESCRIPTION
기존 유저를 저장하고 토큰을 받아오는 Service에서 로그아웃,회원탈퇴등 카카오API와 통신을 위해 다방면으로 쓰일수 있게  코드를 수정했습니다.