### PR TITLE
[feat] 가게 삭제 API 추가 및 조회, 명령 서비스 분리

### DIFF
--- a/src/main/java/com/cakestation/backend/cakestore/controller/CakeStoreController.java
+++ b/src/main/java/com/cakestation/backend/cakestore/controller/CakeStoreController.java
@@ -1,5 +1,6 @@
 package com.cakestation.backend.cakestore.controller;
 
+import com.cakestation.backend.cakestore.service.CakeStoreQueryService;
 import com.cakestation.backend.common.ApiResponse;
 import com.cakestation.backend.cakestore.controller.dto.response.CakeStoreResponse;
 import com.cakestation.backend.cakestore.service.CakeStoreService;
@@ -26,6 +27,7 @@ import java.util.stream.Collectors;
 public class CakeStoreController {
 
     private final CakeStoreService cakeStoreService;
+    private final CakeStoreQueryService cakeStoreQueryService;
     private final UtilService utilService;
 
     @ResponseStatus(HttpStatus.CREATED)
@@ -39,15 +41,23 @@ public class CakeStoreController {
     @ResponseStatus(HttpStatus.OK)
     @GetMapping("/stores/{storeId}")
     public ResponseEntity<ApiResponse<CakeStoreResponse>> showStore(@PathVariable Long storeId) {
-        CakeStoreResponse storeResponse = CakeStoreResponse.from(cakeStoreService.findStoreById(storeId));
+        CakeStoreResponse storeResponse = CakeStoreResponse.from(cakeStoreQueryService.findStoreById(storeId));
         return ResponseEntity.ok()
                 .body(new ApiResponse<>(HttpStatus.OK.value(), "가게 조회 성공", storeResponse));
     }
 
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @DeleteMapping("/stores/{storeId}")
+    public ResponseEntity<Void> deleteStore(@PathVariable Long storeId) {
+        cakeStoreService.deleteStore(storeId);
+        return ResponseEntity.noContent().build();
+    }
+
+
     @ResponseStatus(HttpStatus.OK)
     @GetMapping("/stores/all")
     public ResponseEntity<ApiResponse<List<CakeStoreResponse>>> showAllStores() {
-        List<CakeStoreResponse> storeResponseList = cakeStoreService.findAllStore()
+        List<CakeStoreResponse> storeResponseList = cakeStoreQueryService.findAllStore()
                 .stream()
                 .map(CakeStoreResponse::from)
                 .collect(Collectors.toList());
@@ -61,7 +71,7 @@ public class CakeStoreController {
             @RequestParam String name,
             @PageableDefault(size = 30, sort = {"reviewCount", "reviewScore"}, direction = Sort.Direction.DESC) Pageable pageable) {
 
-        List<CakeStoreResponse> storeResponseList = cakeStoreService.searchStoresByKeyword(name, pageable)
+        List<CakeStoreResponse> storeResponseList = cakeStoreQueryService.searchStoresByKeyword(name, pageable)
                 .stream()
                 .map(CakeStoreResponse::from)
                 .collect(Collectors.toList());
@@ -75,7 +85,7 @@ public class CakeStoreController {
             @RequestParam String name,
             @PageableDefault(size = 30, sort = {"reviewCount", "reviewScore"}, direction = Sort.Direction.DESC) Pageable pageable) {
 
-        List<CakeStoreResponse> storeResponseList = cakeStoreService.searchStoresByStation(name, pageable)
+        List<CakeStoreResponse> storeResponseList = cakeStoreQueryService.searchStoresByStation(name, pageable)
                 .stream()
                 .map(CakeStoreResponse::from)
                 .collect(Collectors.toList());
@@ -99,7 +109,7 @@ public class CakeStoreController {
     public ResponseEntity<ApiResponse<List<CakeStoreDto>>> likeStoreList(HttpServletRequest request) {
 
         String userEmail = utilService.getCurrentUserEmail(request.getHeader(JwtProperties.HEADER_STRING));
-        List<CakeStoreDto> cakeStoreDtoList = cakeStoreService.findAllLikeStore(userEmail);
+        List<CakeStoreDto> cakeStoreDtoList = cakeStoreQueryService.findAllLikeStore(userEmail);
 
         return ResponseEntity.ok()
                 .body(new ApiResponse<>(HttpStatus.OK.value(), "좋아요 리스트 조회 성공", cakeStoreDtoList));

--- a/src/main/java/com/cakestation/backend/cakestore/service/CakeStoreQueryService.java
+++ b/src/main/java/com/cakestation/backend/cakestore/service/CakeStoreQueryService.java
@@ -1,0 +1,97 @@
+package com.cakestation.backend.cakestore.service;
+
+import com.cakestation.backend.cakestore.domain.CakeStore;
+import com.cakestation.backend.cakestore.domain.LikeStore;
+import com.cakestation.backend.cakestore.exception.InvalidStoreException;
+import com.cakestation.backend.cakestore.repository.CakeStoreRepository;
+import com.cakestation.backend.cakestore.repository.LikeStoreRepository;
+import com.cakestation.backend.cakestore.service.dto.CakeStoreDto;
+import com.cakestation.backend.common.exception.ErrorType;
+import com.cakestation.backend.review.domain.Review;
+import com.cakestation.backend.review.domain.ReviewImage;
+import com.cakestation.backend.user.domain.User;
+import com.cakestation.backend.user.exception.InvalidUserException;
+import com.cakestation.backend.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CakeStoreQueryService {
+
+    private final CakeStoreRepository cakeStoreRepository;
+    private final UserRepository userRepository;
+    private final LikeStoreRepository likeStoreRepository;
+
+    public CakeStoreDto findStoreById(Long storeId) {
+        CakeStore cakeStore = cakeStoreRepository.findById(storeId)
+                .orElseThrow(() -> new InvalidStoreException(ErrorType.NOT_FOUND_STORE));
+        List<String> reviewImageUrls = getReviewImageUrls(cakeStore);
+
+        return CakeStoreDto.from(cakeStore, reviewImageUrls);
+    }
+
+    public List<CakeStoreDto> findAllStore() {
+        return cakeStoreRepository.findAll()
+                .stream()
+                .map(store -> CakeStoreDto.from(store, getReviewImageUrls(store)))
+                .collect(Collectors.toList());
+    }
+
+    public List<CakeStoreDto> searchStoresByKeyword(String storeName, Pageable pageable) {
+        List<CakeStore> stores = cakeStoreRepository.findAllByNameContains(storeName, pageable);
+        return stores.stream()
+                .map(store -> CakeStoreDto.from(store, getReviewImageUrls(store)))
+                .collect(Collectors.toList());
+    }
+
+    public List<CakeStoreDto> searchStoresByStation(String stationName, Pageable pageable) {
+        List<CakeStore> stores = cakeStoreRepository.findAllByNearByStationContains(stationName, pageable);
+        return stores.stream()
+                .map(store -> CakeStoreDto.from(store, getReviewImageUrls(store)))
+                .collect(Collectors.toList());
+    }
+
+    public List<CakeStoreDto> findAllLikeStore(String userEmail) {
+        User targetUser = userRepository.findUserByEmail(userEmail)
+                .orElseThrow(() -> new InvalidUserException(ErrorType.NOT_FOUND_USER));
+
+        List<CakeStore> cakeStores = likeStoreRepository.findLikeStoresByUser(targetUser)
+                .stream()
+                .map(LikeStore::getCakeStore)
+                .collect(Collectors.toList());
+
+        List<Long> cakeStoreIds = cakeStores
+                .stream()
+                .map(CakeStore::getId)
+                .collect(Collectors.toList());
+
+        return cakeStoreRepository.findAllById(cakeStoreIds)
+                .stream()
+                .map(store -> CakeStoreDto.from(store, getReviewImageUrls(store)))
+                .collect(Collectors.toList());
+    }
+
+    private List<String> getReviewImageUrls(CakeStore store) {
+
+        return getReviewImages(store)
+                .stream()
+                .map(ReviewImage::getUrl)
+                .collect(Collectors.toList());
+    }
+
+    private List<ReviewImage> getReviewImages(CakeStore store) {
+        return store.getReviews()
+                .stream()
+                .map(Review::getReviewImages)
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/cakestation/backend/cakestore/service/CakeStoreService.java
+++ b/src/main/java/com/cakestation/backend/cakestore/service/CakeStoreService.java
@@ -1,32 +1,30 @@
 package com.cakestation.backend.cakestore.service;
 
-import com.cakestation.backend.cakestore.domain.LikeStore;
 import com.cakestation.backend.cakestore.domain.CakeStore;
+import com.cakestation.backend.cakestore.domain.LikeStore;
 import com.cakestation.backend.cakestore.exception.InvalidStoreException;
-import com.cakestation.backend.cakestore.repository.LikeStoreRepository;
 import com.cakestation.backend.cakestore.repository.CakeStoreRepository;
-import com.cakestation.backend.cakestore.service.dto.CakeStoreDto;
+import com.cakestation.backend.cakestore.repository.LikeStoreRepository;
 import com.cakestation.backend.cakestore.service.dto.CreateCakeStoreDto;
 import com.cakestation.backend.common.exception.ErrorType;
 import com.cakestation.backend.review.domain.Review;
-import com.cakestation.backend.review.domain.ReviewImage;
+import com.cakestation.backend.review.repository.ReviewRepository;
 import com.cakestation.backend.user.domain.User;
 import com.cakestation.backend.user.exception.InvalidUserException;
 import com.cakestation.backend.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
-@Transactional(readOnly = true)
+@Transactional
 @RequiredArgsConstructor
 public class CakeStoreService {
     private final CakeStoreRepository cakeStoreRepository;
+    private final ReviewRepository reviewRepository;
     private final UserRepository userRepository;
     private final LikeStoreRepository likeStoreRepository;
 
@@ -34,35 +32,6 @@ public class CakeStoreService {
     public Long saveStore(CreateCakeStoreDto createStoreDto) {
         CakeStore store = CakeStore.createCakeStore(createStoreDto);
         return cakeStoreRepository.save(store).getId();
-    }
-
-    public CakeStoreDto findStoreById(Long storeId) {
-        CakeStore cakeStore = cakeStoreRepository.findById(storeId)
-                .orElseThrow(() -> new InvalidStoreException(ErrorType.NOT_FOUND_STORE));
-        List<String> reviewImageUrls = getReviewImageUrls(cakeStore);
-
-        return CakeStoreDto.from(cakeStore, reviewImageUrls);
-    }
-
-    public List<CakeStoreDto> findAllStore() {
-        return cakeStoreRepository.findAll()
-                .stream()
-                .map(store -> CakeStoreDto.from(store, getReviewImageUrls(store)))
-                .collect(Collectors.toList());
-    }
-
-    public List<CakeStoreDto> searchStoresByKeyword(String storeName, Pageable pageable) {
-        List<CakeStore> stores = cakeStoreRepository.findAllByNameContains(storeName, pageable);
-        return stores.stream()
-                .map(store -> CakeStoreDto.from(store, getReviewImageUrls(store)))
-                .collect(Collectors.toList());
-    }
-
-    public List<CakeStoreDto> searchStoresByStation(String stationName, Pageable pageable) {
-        List<CakeStore> stores = cakeStoreRepository.findAllByNearByStationContains(stationName, pageable);
-        return stores.stream()
-                .map(store -> CakeStoreDto.from(store, getReviewImageUrls(store)))
-                .collect(Collectors.toList());
     }
 
     @Transactional
@@ -77,39 +46,20 @@ public class CakeStoreService {
                         () -> likeStoreRepository.save(LikeStore.createLikeStore(targetUser, cakeStore)));
     }
 
-    public List<CakeStoreDto> findAllLikeStore(String userEmail) {
-        User targetUser = userRepository.findUserByEmail(userEmail)
-                .orElseThrow(() -> new InvalidUserException(ErrorType.NOT_FOUND_USER));
+    @Transactional
+    public void deleteStore(Long storeId) {
+        CakeStore cakeStore = cakeStoreRepository.findById(storeId)
+                .orElseThrow(() -> new InvalidStoreException(ErrorType.NOT_FOUND_STORE));
 
-        List<CakeStore> cakeStores = likeStoreRepository.findLikeStoresByUser(targetUser)
+        List<Long> reviewIds = cakeStore.getReviews()
                 .stream()
-                .map(LikeStore::getCakeStore)
+                .map(Review::getId)
                 .collect(Collectors.toList());
 
-        List<Long> cakeStoreIds = cakeStores
-                .stream()
-                .map(CakeStore::getId)
-                .collect(Collectors.toList());
+        reviewRepository.deleteReviewImagesByReviewIds(reviewIds);
+        reviewRepository.deleteReviewTagsByReviewIds(reviewIds);
+        reviewRepository.deleteReviewByIds(reviewIds);
 
-        return cakeStoreRepository.findAllById(cakeStoreIds)
-                .stream()
-                .map(store -> CakeStoreDto.from(store, getReviewImageUrls(store)))
-                .collect(Collectors.toList());
-    }
-
-    private List<String> getReviewImageUrls(CakeStore store) {
-
-        return getReviewImages(store)
-                .stream()
-                .map(ReviewImage::getUrl)
-                .collect(Collectors.toList());
-    }
-
-    private List<ReviewImage> getReviewImages(CakeStore store) {
-        return store.getReviews()
-                .stream()
-                .map(Review::getReviewImages)
-                .flatMap(Collection::stream)
-                .collect(Collectors.toList());
+        cakeStoreRepository.deleteById(cakeStore.getId());
     }
 }

--- a/src/main/java/com/cakestation/backend/review/repository/ReviewRepository.java
+++ b/src/main/java/com/cakestation/backend/review/repository/ReviewRepository.java
@@ -16,6 +16,18 @@ import java.util.Optional;
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
+    @Modifying(clearAutomatically = true)
+    @Query("delete from Review r where r.id in :ids")
+    void deleteReviewByIds(@Param("ids") List<Long> ids);
+
+    @Modifying(clearAutomatically = true)
+    @Query("delete from ReviewImage ri where ri.review.id in :ids")
+    void deleteReviewImagesByReviewIds(@Param("ids") List<Long> ids);
+
+    @Modifying(clearAutomatically = true)
+    @Query("delete from ReviewTag rt where rt.review.id in :ids")
+    void deleteReviewTagsByReviewIds(@Param("ids") List<Long> ids);
+
     @EntityGraph(attributePaths = {"writer"})
     List<Review> findAllByWriterId(Long writerId, Pageable pageable);
 
@@ -29,11 +41,4 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     @Query("select r from Review r where r.writer.id =:writerId")
     List<Review> findAllByWriter(@Param("writerId") Long writerId);
 
-    @Modifying
-    @Query("delete from ReviewImage ri where ri.review.id =:reviewId")
-    void deleteReviewImageById(@Param("reviewId") Long reviewId);
-
-    @Modifying
-    @Query("delete from ReviewTag rt where rt.review.id =:reviewId")
-    void deleteReviewTagById(@Param("reviewId") Long reviewId);
 }

--- a/src/main/java/com/cakestation/backend/review/service/ReviewQueryService.java
+++ b/src/main/java/com/cakestation/backend/review/service/ReviewQueryService.java
@@ -1,24 +1,15 @@
 package com.cakestation.backend.review.service;
 
-import com.cakestation.backend.cakestore.domain.CakeStore;
 import com.cakestation.backend.cakestore.exception.InvalidStoreException;
-import com.cakestation.backend.cakestore.repository.CakeStoreRepository;
 import com.cakestation.backend.common.exception.ErrorType;
 import com.cakestation.backend.review.domain.Review;
 import com.cakestation.backend.review.domain.ReviewImage;
 import com.cakestation.backend.review.domain.ReviewTag;
 import com.cakestation.backend.review.domain.Tag;
 import com.cakestation.backend.review.exception.InvalidReviewException;
-import com.cakestation.backend.review.repository.ReviewImageRepository;
 import com.cakestation.backend.review.repository.ReviewRepository;
-import com.cakestation.backend.review.repository.ReviewTagRepository;
-import com.cakestation.backend.review.service.dto.CreateReviewDto;
 import com.cakestation.backend.review.service.dto.ReviewDto;
 import com.cakestation.backend.review.service.dto.ReviewImageDto;
-import com.cakestation.backend.review.service.dto.UpdateReviewDto;
-import com.cakestation.backend.user.domain.User;
-import com.cakestation.backend.user.exception.InvalidUserException;
-import com.cakestation.backend.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -31,52 +22,10 @@ import java.util.stream.Collectors;
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
-public class ReviewServiceImpl implements ReviewService {
+public class ReviewQueryService {
 
-    private final ImageUploadService imageUploadService;
-    private final UserRepository userRepository;
-    private final CakeStoreRepository cakeStoreRepository;
     private final ReviewRepository reviewRepository;
-    private final ReviewImageRepository reviewImageRepository;
-    private final ReviewTagRepository reviewTagRepository;
 
-
-    @Override
-    @Transactional
-    public Long saveReview(CreateReviewDto createReviewDto, String currentEmail) {
-
-        User user = userRepository.findUserByEmail(currentEmail).orElseThrow(
-                () -> new InvalidUserException(ErrorType.NOT_FOUND_USER));
-
-        CakeStore cakeStore = cakeStoreRepository.findCakeStoreForUpdateById(createReviewDto.getStoreId())
-                .orElseThrow(() -> new InvalidStoreException(ErrorType.NOT_FOUND_STORE));
-
-        List<String> imageUrls = imageUploadService.uploadFiles(createReviewDto.getReviewImages());
-        createReviewDto.setImageUrls(imageUrls);
-
-        Review review = reviewRepository.save(Review.createReview(user, cakeStore, createReviewDto));
-
-        return review.getId();
-    }
-
-    @Override
-    @Transactional
-    public ReviewDto updateReview(UpdateReviewDto updateReviewDto, Long reviewId) {
-        reviewImageRepository.deleteReviewImageByIds(reviewImageRepository.findAllIdByReviewId(reviewId));
-        reviewTagRepository.deleteReviewTagByIds(reviewTagRepository.findAllIdByReviewId(reviewId));
-
-        Review review = reviewRepository.findById(reviewId)
-                .orElseThrow(() -> new InvalidReviewException(ErrorType.NOT_FOUND_REVIEW));
-
-        List<String> imageUrls = imageUploadService.uploadFiles(updateReviewDto.getReviewImages());
-        updateReviewDto.setImageUrls(imageUrls);
-
-        review.update(updateReviewDto);
-
-        return ReviewDto.from(review, getTags(review), imageUrls);
-    }
-
-    @Override
     public ReviewDto findReviewById(Long reviewId) {
         Review review =
                 reviewRepository.findById(reviewId).orElseThrow(
@@ -86,7 +35,6 @@ public class ReviewServiceImpl implements ReviewService {
         return ReviewDto.from(review, tags, getImageUrls(review));
     }
 
-    @Override
     public List<ReviewDto> findReviewsByWriter(Long writerId, Pageable pageable) {
         List<Review> reviews = reviewRepository.findAllByWriterId(writerId, pageable);
         return reviews.stream()
@@ -94,7 +42,6 @@ public class ReviewServiceImpl implements ReviewService {
                 .collect(Collectors.toList());
     }
 
-    @Override
     public List<ReviewDto> findReviewsByStore(Long cakeStoreId, Pageable pageable) {
 
         List<Review> reviews = reviewRepository.findAllByCakeStoreId(cakeStoreId, pageable);
@@ -103,36 +50,18 @@ public class ReviewServiceImpl implements ReviewService {
                 .collect(Collectors.toList());
     }
 
-    @Override
     public Double findReviewAvgByStore(Long storeId) {
         return reviewRepository.findAverageByStore(storeId).orElseThrow(
                 () -> new InvalidStoreException(ErrorType.NOT_FOUND_STORE)
         );
     }
 
-    @Override
-    @Transactional
-    public void deleteReview(Long reviewId, String currentEmail) {
-        Review review = reviewRepository.findById(reviewId)
-                .orElseThrow(() -> new InvalidReviewException(ErrorType.NOT_FOUND_REVIEW));
-
-        if (!review.getWriter().getEmail().equals(currentEmail)) {
-            throw new InvalidUserException(ErrorType.FORBIDDEN);
-        }
-
-        reviewImageRepository.deleteReviewImageByIds(reviewImageRepository.findAllIdByReviewId(reviewId));
-        reviewTagRepository.deleteReviewTagByIds(reviewTagRepository.findAllIdByReviewId(reviewId));
-        reviewRepository.deleteById(reviewId);
-    }
-
-    @Override
     public List<ReviewImageDto> findReviewImagesByStore(Long storeId, Pageable pageable) {
         List<Review> reviews = reviewRepository.findAllByCakeStoreId(storeId, pageable);
 
         return collectReviewImageDto(reviews);
     }
 
-    @Override
     public List<ReviewImageDto> findReviewImagesByUser(Long userId, Pageable pageable) {
         List<Review> reviews = reviewRepository.findAllByWriterId(userId, pageable);
 

--- a/src/main/java/com/cakestation/backend/review/service/ReviewService.java
+++ b/src/main/java/com/cakestation/backend/review/service/ReviewService.java
@@ -1,21 +1,88 @@
 package com.cakestation.backend.review.service;
 
+import com.cakestation.backend.cakestore.domain.CakeStore;
+import com.cakestation.backend.cakestore.exception.InvalidStoreException;
+import com.cakestation.backend.cakestore.repository.CakeStoreRepository;
+import com.cakestation.backend.common.exception.ErrorType;
+import com.cakestation.backend.review.domain.Review;
+import com.cakestation.backend.review.domain.ReviewTag;
+import com.cakestation.backend.review.domain.Tag;
+import com.cakestation.backend.review.exception.InvalidReviewException;
+import com.cakestation.backend.review.repository.ReviewRepository;
 import com.cakestation.backend.review.service.dto.CreateReviewDto;
 import com.cakestation.backend.review.service.dto.ReviewDto;
-import com.cakestation.backend.review.service.dto.ReviewImageDto;
 import com.cakestation.backend.review.service.dto.UpdateReviewDto;
-import org.springframework.data.domain.Pageable;
+import com.cakestation.backend.user.domain.User;
+import com.cakestation.backend.user.exception.InvalidUserException;
+import com.cakestation.backend.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
-public interface ReviewService {
-    Long saveReview(CreateReviewDto createReviewDto, String currentEmail);
-    ReviewDto updateReview(UpdateReviewDto updateReviewDto, Long reviewId);
-    ReviewDto findReviewById(Long reviewId);
-    List<ReviewDto> findReviewsByWriter(Long writerId, Pageable pageable);
-    List<ReviewDto> findReviewsByStore(Long storeId, Pageable pageable);
-    Double findReviewAvgByStore(Long storeId);
-    void deleteReview(Long reviewId, String currentEmail);
-    List<ReviewImageDto> findReviewImagesByStore(Long storeId, Pageable pageable);
-    List<ReviewImageDto> findReviewImagesByUser(Long userId, Pageable pageable);
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ReviewService {
+
+    private final ImageUploadService imageUploadService;
+    private final UserRepository userRepository;
+    private final CakeStoreRepository cakeStoreRepository;
+    private final ReviewRepository reviewRepository;
+
+    @Transactional
+    public Long saveReview(CreateReviewDto createReviewDto, String currentEmail) {
+
+        User user = userRepository.findUserByEmail(currentEmail).orElseThrow(
+                () -> new InvalidUserException(ErrorType.NOT_FOUND_USER));
+
+        CakeStore cakeStore = cakeStoreRepository.findCakeStoreForUpdateById(createReviewDto.getStoreId())
+                .orElseThrow(() -> new InvalidStoreException(ErrorType.NOT_FOUND_STORE));
+
+        List<String> imageUrls = imageUploadService.uploadFiles(createReviewDto.getReviewImages());
+        createReviewDto.setImageUrls(imageUrls);
+
+        Review review = reviewRepository.save(Review.createReview(user, cakeStore, createReviewDto));
+
+        return review.getId();
+    }
+
+    @Transactional
+    public ReviewDto updateReview(UpdateReviewDto updateReviewDto, Long reviewId) {
+        reviewRepository.deleteReviewImagesByReviewIds(List.of(reviewId));
+        reviewRepository.deleteReviewTagsByReviewIds(List.of(reviewId));
+
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new InvalidReviewException(ErrorType.NOT_FOUND_REVIEW));
+
+        List<String> imageUrls = imageUploadService.uploadFiles(updateReviewDto.getReviewImages());
+        updateReviewDto.setImageUrls(imageUrls);
+
+        review.update(updateReviewDto);
+
+        return ReviewDto.from(review, getTags(review), imageUrls);
+    }
+
+    @Transactional
+    public void deleteReview(Long reviewId, String currentEmail) {
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new InvalidReviewException(ErrorType.NOT_FOUND_REVIEW));
+
+        if (!review.getWriter().getEmail().equals(currentEmail)) {
+            throw new InvalidUserException(ErrorType.FORBIDDEN);
+        }
+
+        reviewRepository.deleteReviewImagesByReviewIds(List.of(reviewId));
+        reviewRepository.deleteReviewTagsByReviewIds(List.of(reviewId));
+        reviewRepository.deleteById(reviewId);
+    }
+
+    private List<Tag> getTags(Review review) {
+        return review.getReviewTags()
+                .stream()
+                .map(ReviewTag::getTag)
+                .collect(Collectors.toList());
+    }
 }

--- a/src/test/java/com/cakestation/backend/cakestore/controller/CakeStoreControllerTest.java
+++ b/src/test/java/com/cakestation/backend/cakestore/controller/CakeStoreControllerTest.java
@@ -15,7 +15,6 @@ import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 import static com.cakestation.backend.cakestore.fixture.StoreFixture.getCreateCakeStoreDto;
 import static com.cakestation.backend.user.fixture.UserFixture.getKakaoUserDto;

--- a/src/test/java/com/cakestation/backend/cakestore/service/CakeStoreServiceUnitTest.java
+++ b/src/test/java/com/cakestation/backend/cakestore/service/CakeStoreServiceUnitTest.java
@@ -22,7 +22,7 @@ class CakeStoreServiceUnitTest {
     CakeStoreRepository cakeStoreRepository;
 
     @InjectMocks
-    CakeStoreService cakeStoreService;
+    CakeStoreQueryService cakeStoreQueryService;
 
     @Test
     void 가게_등록() {
@@ -34,7 +34,7 @@ class CakeStoreServiceUnitTest {
         doReturn(Optional.of(getCakeStoreEntity())).when(cakeStoreRepository).findById(any());
 
         // when
-        CakeStoreDto store = cakeStoreService.findStoreById(STORE_ID);
+        CakeStoreDto store = cakeStoreQueryService.findStoreById(STORE_ID);
 
         // then
         assertEquals(store.getStoreId(),STORE_ID);

--- a/src/test/java/com/cakestation/backend/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/cakestation/backend/review/controller/ReviewControllerTest.java
@@ -3,6 +3,7 @@ package com.cakestation.backend.review.controller;
 
 import com.cakestation.backend.review.controller.dto.request.CreateReviewRequest;
 import com.cakestation.backend.review.fixture.ReviewFixture;
+import com.cakestation.backend.review.service.ReviewQueryService;
 import com.cakestation.backend.review.service.ReviewService;
 import com.cakestation.backend.review.service.dto.CreateReviewDto;
 import com.cakestation.backend.cakestore.service.CakeStoreService;
@@ -38,6 +39,8 @@ class ReviewControllerTest {
     private MockMvc mockMvc;
     @Autowired
     private ReviewService reviewService;
+    @Autowired
+    private ReviewQueryService reviewQueryService;
 
     @Autowired
     private CakeStoreService cakeStoreService;

--- a/src/test/java/com/cakestation/backend/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/cakestation/backend/review/controller/ReviewControllerTest.java
@@ -16,7 +16,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;

--- a/src/test/java/com/cakestation/backend/review/service/ReviewServiceUnitTest.java
+++ b/src/test/java/com/cakestation/backend/review/service/ReviewServiceUnitTest.java
@@ -34,7 +34,9 @@ class ReviewServiceUnitTest {
     @Mock
     ImageUploadService imageUploadService;
     @InjectMocks
-    ReviewServiceImpl reviewService;
+    ReviewService reviewService;
+    @InjectMocks
+    ReviewQueryService reviewQueryService;
 
     @Test
     void 리뷰_등록() {
@@ -56,7 +58,7 @@ class ReviewServiceUnitTest {
         // given
         doReturn(Optional.of(getReviewEntity())).when(reviewRepository).findById(any());
         // when
-        ReviewDto reviewDto = reviewService.findReviewById(REVIEW_ID);
+        ReviewDto reviewDto = reviewQueryService.findReviewById(REVIEW_ID);
         // then
         assertEquals(REVIEW_ID,reviewDto.getReviewId());
 
@@ -69,7 +71,7 @@ class ReviewServiceUnitTest {
 
         // when
         PageRequest pageRequest = PageRequest.of(0, 1);
-        List<ReviewDto> reviewDtoList = reviewService.findReviewsByWriter(USER_ID, pageRequest);
+        List<ReviewDto> reviewDtoList = reviewQueryService.findReviewsByWriter(USER_ID, pageRequest);
 
         // then
         assertEquals(NICKNAME, reviewDtoList.get(0).getNickname());
@@ -82,7 +84,7 @@ class ReviewServiceUnitTest {
 
         // when
         PageRequest pageRequest = PageRequest.of(0, 1);
-        List<ReviewDto> reviewDtoList = reviewService.findReviewsByStore(STORE_ID, pageRequest);
+        List<ReviewDto> reviewDtoList = reviewQueryService.findReviewsByStore(STORE_ID, pageRequest);
 
         // then
         assertEquals(NICKNAME, reviewDtoList.get(0).getNickname());
@@ -95,7 +97,7 @@ class ReviewServiceUnitTest {
 
         // when
         PageRequest pageRequest = PageRequest.of(0, 1);
-        List<ReviewImageDto> reviewImageDtoList = reviewService.findReviewImagesByStore(STORE_ID, pageRequest);
+        List<ReviewImageDto> reviewImageDtoList = reviewQueryService.findReviewImagesByStore(STORE_ID, pageRequest);
 
         // then
         assertEquals(reviewImageDtoList.size(), REVIEW_IMAGES.size());

--- a/src/test/java/com/cakestation/backend/user/service/UserServiceUnitTest.java
+++ b/src/test/java/com/cakestation/backend/user/service/UserServiceUnitTest.java
@@ -1,9 +1,5 @@
 package com.cakestation.backend.user.service;
 
-import com.cakestation.backend.common.exception.ErrorType;
-import com.cakestation.backend.review.service.ReviewServiceImpl;
-import com.cakestation.backend.user.domain.User;
-import com.cakestation.backend.user.exception.InvalidUserException;
 import com.cakestation.backend.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,10 +12,8 @@ import java.util.Optional;
 
 import static com.cakestation.backend.user.fixture.UserFixture.getUserEntity;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class UserServiceUnitTest {


### PR DESCRIPTION
- 가게 및 관련 리뷰 한번에 삭제하는 API 구현
- 코드 간결성 및 가독성을 위해 조회, 명령 서비스 분리